### PR TITLE
make command prefix character configurable

### DIFF
--- a/bestof.go
+++ b/bestof.go
@@ -18,11 +18,11 @@ type BestOf struct {
 	mutex          *sync.Mutex
 }
 
-func BEST_OF(filename string) *BestOf {
+func BEST_OF(filename, p string) *BestOf {
 	bestOf := BestOf{
-		commandPattern: regexp.MustCompile("^[^ ]+ PRIVMSG ([^ ]+) :#bestof.*$"),
-		indexPattern:   regexp.MustCompile("^[^ ]+ PRIVMSG ([^ ]+) :#bestof #([0-9]+)"),
-		processPattern: regexp.MustCompile("^[^ ]+ PRIVMSG ([^ ]+) :#bestof([^ ]*)(.*)$"),
+		commandPattern: regexp.MustCompile(fmt.Sprintf("^[^ ]+ PRIVMSG ([^ ]+) :%sbestof.*$", p)),
+		indexPattern:   regexp.MustCompile(fmt.Sprintf("^[^ ]+ PRIVMSG ([^ ]+) :%sbestof #([0-9]+)", p)),
+		processPattern: regexp.MustCompile(fmt.Sprintf("^[^ ]+ PRIVMSG ([^ ]+) :%sbestof([^ ]*)(.*)$", p)),
 		filename:       filename,
 		mutex:          &sync.Mutex{},
 	}

--- a/bestof_test.go
+++ b/bestof_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestBestOfCountEmpty(t *testing.T) {
-	bestof := BEST_OF("")
+	bestof := BEST_OF("", "#")
 	_, response := bestof.process(":tester!tester@test.irc.server.org PRIVMSG #bla :#bestof-count")
 	if response != "I've got 0 bestof entries." {
 		t.Errorf("Invalid count on empty bestof. %q", response)
@@ -15,7 +15,7 @@ func TestBestOfCountEmpty(t *testing.T) {
 
 func TestBestOfAdd(t *testing.T) {
 	var response string
-	bestof := BEST_OF("")
+	bestof := BEST_OF("", "#")
 	_, response = bestof.process(":tester!tester@test.irc.server.org PRIVMSG #bla :#bestof-add hello world")
 	if response != "Ok. Added. Got 1 bestof entry now." {
 		t.Errorf("Invalid response on first bestof-add. %q", response)
@@ -67,7 +67,7 @@ func TestBestOfIndexZero(t *testing.T) {
 }
 
 func exampleBestOf() *BestOf {
-	bestof := BEST_OF("")
+	bestof := BEST_OF("", "#")
 	bestof.Add("entry one")
 	bestof.Add("entry two")
 	bestof.Add("entry three")

--- a/calc.go
+++ b/calc.go
@@ -9,9 +9,9 @@ type Calc struct {
 	pattern *regexp.Regexp
 }
 
-func CALC() *Calc {
+func CALC(p string) *Calc {
 	return &Calc{
-		pattern: regexp.MustCompile("^[^ ]+ PRIVMSG ([^ ]+) :#calc(.*)$"),
+		pattern: regexp.MustCompile(fmt.Sprintf("^[^ ]+ PRIVMSG ([^ ]+) :%scalc(.*)$", p)),
 	}
 }
 

--- a/calc_test.go
+++ b/calc_test.go
@@ -3,22 +3,22 @@ package main
 import "testing"
 
 func TestCalcCommandMatch(t *testing.T) {
-	if !CALC().Match(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc") {
+	if !CALC("#").Match(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc") {
 		t.Error("pattern not matching as expected: !calc")
 	}
-	if !CALC().Match(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc ") {
+	if !CALC("#").Match(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc ") {
 		t.Error("pattern not matching as expected. !calc ")
 	}
-	if !CALC().Match(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc 2 + 2") {
+	if !CALC("#").Match(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc 2 + 2") {
 		t.Error("pattern not matching as expected. !calc 2 + 2")
 	}
-	if !CALC().Match(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc 2+2") {
+	if !CALC("#").Match(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc 2+2") {
 		t.Error("pattern not matching as expected. !calc 2+2")
 	}
 }
 
 func TestCalcProcess(t *testing.T) {
-	calc := CALC()
+	calc := CALC("#")
 	channel, result := calc.process(":tester!tester@test.irc.server.org PRIVMSG #bla :#calc 2 + 2")
 	if channel != "#bla" {
 		t.Errorf("invalid channel %q", channel)
@@ -29,7 +29,7 @@ func TestCalcProcess(t *testing.T) {
 }
 
 func TestCalculate(t *testing.T) {
-	calc := CALC()
+	calc := CALC("#")
 	if result, err := calc.calculate("(1+1)*(2+2)"); result != "8" {
 		t.Errorf("invalid result %s, %q", result, err)
 	}

--- a/cite.go
+++ b/cite.go
@@ -16,11 +16,11 @@ type Cite struct {
 	entries        StringList
 }
 
-func CITE(shortCut, filename string) *Cite {
+func CITE(shortCut, filename, p string) *Cite {
 	cite := Cite{
-		commandPattern: regexp.MustCompile("^[^ ]+ PRIVMSG ([^ ]+) :#" + shortCut + ".*$"),
-		indexPattern:   regexp.MustCompile("^[^ ]+ PRIVMSG ([^ ]+) :#" + shortCut + " #([0-9]+)"),
-		processPattern: regexp.MustCompile("^[^ ]+ PRIVMSG ([^ ]+) :#" + shortCut + " *([^ ]*)$"),
+		commandPattern: regexp.MustCompile(fmt.Sprintf("^[^ ]+ PRIVMSG ([^ ]+) :%s"+shortCut+".*$", p)),
+		indexPattern:   regexp.MustCompile(fmt.Sprintf("^[^ ]+ PRIVMSG ([^ ]+) :%s"+shortCut+" #([0-9]+)", p)),
+		processPattern: regexp.MustCompile(fmt.Sprintf("^[^ ]+ PRIVMSG ([^ ]+) :%s"+shortCut+" *([^ ]*)$", p)),
 		shortCut:       shortCut,
 	}
 	if file, err := os.Open(filename); err != nil {

--- a/cite_test.go
+++ b/cite_test.go
@@ -3,7 +3,7 @@ package main
 import "testing"
 
 func TestEmptyCiteFile(t *testing.T) {
-	cite := CITE("test", "examples/empty.txt")
+	cite := CITE("test", "examples/empty.txt", "#")
 	_, response := cite.process(":tester!tester@test.irc.server.org PRIVMSG #bla :#test")
 	if response != "test[0/0]: -- no entries --" {
 		t.Errorf("Invalid random cite on empty database. %q", response)
@@ -11,7 +11,7 @@ func TestEmptyCiteFile(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	cite := CITE("test", "examples/cites.txt")
+	cite := CITE("test", "examples/cites.txt", "#")
 	_, response := cite.process(":tester!tester@test.irc.server.org PRIVMSG #bla :#test another")
 	if response != "test[1/1]: another one" {
 		t.Errorf("Invalid filtered cite. %q", response)
@@ -19,7 +19,7 @@ func TestFilter(t *testing.T) {
 }
 
 func TestFilterNoResult(t *testing.T) {
-	cite := CITE("test", "examples/cites.txt")
+	cite := CITE("test", "examples/cites.txt", "#")
 	_, response := cite.process(":tester!tester@test.irc.server.org PRIVMSG #bla :#test unknown")
 	if response != "test[0/0]: -- no entries --" {
 		t.Errorf("Invalid filtered response without result. %q", response)
@@ -27,7 +27,7 @@ func TestFilterNoResult(t *testing.T) {
 }
 
 func TestCiteIndex(t *testing.T) {
-	cite := CITE("test", "examples/cites.txt")
+	cite := CITE("test", "examples/cites.txt", "#")
 	_, response := cite.process(":tester!tester@test.irc.server.org PRIVMSG #bla :#test #8")
 	if response != "test[8/8]: lorem ipsum" {
 		t.Errorf("Invalid indexed cite. %q", response)

--- a/leave.go
+++ b/leave.go
@@ -9,9 +9,9 @@ type Leave struct {
 	pattern *regexp.Regexp
 }
 
-func LEAVE() *Leave {
+func LEAVE(p string) *Leave {
 	leave := Leave{
-		pattern: regexp.MustCompile("^:(.*)+\\!+[^ ]+ PRIVMSG ([^ ]+) :#kick.*$"),
+		pattern: regexp.MustCompile(fmt.Sprintf("^:(.*)+\\!+[^ ]+ PRIVMSG ([^ ]+) :%skick.*$", p)),
 	}
 	return &leave
 }

--- a/leave_test.go
+++ b/leave_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestLeaveMatchLineLeave(t *testing.T) {
-	me := LEAVE()
+	me := LEAVE("#")
 	b := me.Match(":tester!tester@test.irc.server.org PRIVMSG #channel2 :#kick")
 	if b == false {
 		t.Error("Match wrong result.")
@@ -13,7 +13,7 @@ func TestLeaveMatchLineLeave(t *testing.T) {
 }
 
 func TestLeaveMatchLinePrivMsg(t *testing.T) {
-	me := LEAVE()
+	me := LEAVE("#")
 	b := me.Match(":tester!tester@test.irc.server.org PRIVMSG #bla :what's up guys")
 	if b == true {
 		t.Error("Match wrong result.")
@@ -21,7 +21,7 @@ func TestLeaveMatchLinePrivMsg(t *testing.T) {
 }
 
 func TestLeaveParseLine(t *testing.T) {
-	me := LEAVE()
+	me := LEAVE("#")
 	channel, name := me.parseLine(":tester!tester@test.irc.server.org PRIVMSG #channel2 :#kick")
 	if channel != "#channel2" {
 		t.Error("Wrong value for channel.")

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	bestofPtr := flag.String("b", "/tmp/girc-bestof.json", "bestof-data-file")
 	mePtr := flag.String("me", "", "me-data-file")
 	matrixPtr := flag.String("m", "", "file with one liner cites from matrix (the film)")
+	cmdPrefixPtr := flag.String("t", "!", "prefix to trigger bot commands")
 
 	flag.Parse()
 
@@ -38,15 +39,15 @@ func main() {
 	gossip.addCommand(JOIN())
 	gossip.addCommand(PING())
 
-	gossip.addCommand(CALC())
+	gossip.addCommand(CALC(*cmdPrefixPtr))
 	gossip.addCommand(KICK())
-	gossip.addCommand(BEST_OF(*bestofPtr))
+	gossip.addCommand(BEST_OF(*bestofPtr, *cmdPrefixPtr))
 	gossip.addCommand(ME(gossip.Nick, *mePtr))
 	gossip.addCommand(INVITE())
-	gossip.addCommand(LEAVE())
+	gossip.addCommand(LEAVE(*cmdPrefixPtr))
 
 	if *matrixPtr != "" {
-		gossip.addCommand(CITE("matrix", *matrixPtr))
+		gossip.addCommand(CITE("matrix", *matrixPtr, *cmdPrefixPtr))
 	}
 
 	gossip.start()


### PR DESCRIPTION
Rather than having a hardcoded prefix character for commands,
make this character configurable with the new option "-t".
It defaults to "!".
