### PR TITLE
fix(command): ping: allow all characters for server

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -7,7 +7,7 @@ type Ping struct {
 }
 
 func PING() *Ping {
-	return &Ping{pattern: regexp.MustCompile("^PING :([a-zA-Z0-9\\.]+)$")}
+	return &Ping{pattern: regexp.MustCompile("^PING :(.*)$")}
 }
 
 func (this *Ping) Match(line string) bool {

--- a/ping_test.go
+++ b/ping_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	me := PING()
+	b := me.Match("PING :my-domain.my-host.com")
+	if b == false {
+		t.Errorf("Wrong match value.")
+	}
+}


### PR DESCRIPTION
The pattern for matching the PING command was too restrictive
to match all possible servers (e.g. hostnames containing '-').
Fix this by simply allow all characters.

While at there, add a testcase.
