### PR TITLE
invite: accept invitations without optional channel delimiter

### DIFF
--- a/invite.go
+++ b/invite.go
@@ -11,7 +11,7 @@ type Invite struct {
 
 func INVITE() *Invite {
 	invite := Invite{
-		pattern: regexp.MustCompile("^:(.*)+\\!+[^ ]+ INVITE [^ ]+ :(.*)$"),
+		pattern: regexp.MustCompile("^:(.*)+\\!+[^ ]+ INVITE [^ ]+ :?(.*)$"),
 	}
 	return &invite
 }

--- a/invite_test.go
+++ b/invite_test.go
@@ -10,6 +10,10 @@ func TestInviteMatchLineInvite(t *testing.T) {
 	if b == false {
 		t.Error("Match wrong result.")
 	}
+	b = me.Match(":tester!tester@test.irc.server.org INVITE girc #channel2")
+	if b == false {
+		t.Error("Match wrong result.")
+	}
 }
 
 func TestInviteMatchLinePrivMsg(t *testing.T) {


### PR DESCRIPTION
According to RFC 2812 (1.3 Channels) a colon _can_ be used as
a delimiter for the channel mask. We should accept invitations
in both formats so we should make the colon optional.
